### PR TITLE
fixed out-of-bound error in nblist generation for NN

### DIFF
--- a/src/cu/nn.cu
+++ b/src/cu/nn.cu
@@ -109,13 +109,17 @@ void ref_nblist_cu1(NBLIST_PARAMS)
                if (atomic2species[atomic[j]] == -1) { // remove the atoms not in atomic_covered
                   incl_ij = false;
                }
-               x = atomid_global2local[i];
-               y = atomid_global2local[j];
-               tri = xy_to_tri(max(x, y), min(x, y));
                // only use topo flags when topo_cutoff is set to > 0.
                if (topo_cutoff > 0) {
-                  int incl_topo = topo_flags[tri / WARP_SIZE] & (1 << (tri & (WARP_SIZE - 1)));
-                  incl_ij = incl_ij and incl_topo;
+                  x = atomid_global2local[i];
+                  y = atomid_global2local[j];
+                  if (y == -1) {                      // make sure j is also in nnatoms for NN valence term.
+                     incl_ij = false;
+                  } else {
+                     tri = xy_to_tri(max(x, y), min(x, y));
+                     int incl_topo = topo_flags[tri / WARP_SIZE] & (1 << (tri & (WARP_SIZE - 1)));
+                     incl_ij = incl_ij and incl_topo;
+                  }
                }
             }
 

--- a/src/cu/spatial.cu
+++ b/src/cu/spatial.cu
@@ -486,6 +486,7 @@ void spatialStep5(const int* restrict bnum, const int* restrict iakpl_rev, int n
    // tranditional AMOEBA terms.
    for (int wy = iwarp; wy < (nblist4nn ? nak : nak - 1); wy += nwarp) {
       int atomi = wy * WARP_SIZE + ilane;
+      atomi = min(atomi, n - 1);
       real xi = sorted[atomi].x;
       real yi = sorted[atomi].y;
       real zi = sorted[atomi].z;


### PR DESCRIPTION
There were two out-of-bounds issues. The one in `nn.cu` could affect the inclusion of the farthest neighbor atom, potentially causing unpredictable energy differences for valence NN but the difference should be very small. The one in `spatial.cu` was the one causing all zeros in the energy output. This commit fixes both issues. 